### PR TITLE
Updated SEWorldGenPlugin to latest version

### DIFF
--- a/Plugins/SEWorldGenPlugin_v2/github.xml
+++ b/Plugins/SEWorldGenPlugin_v2/github.xml
@@ -4,5 +4,4 @@
   <FriendlyName>SEWorldGenPlugin V2</FriendlyName>
   <GroupId>SEWorldGenPlugin</GroupId>
   <Commit>7e65a26fbfb5e32d9c940a3aef964218796d92f6</Commit>
-  <Hidden>true</Hidden>
 </PluginData>

--- a/Plugins/SEWorldGenPlugin_v2/github.xml
+++ b/Plugins/SEWorldGenPlugin_v2/github.xml
@@ -3,6 +3,6 @@
   <Id>thorwin99/SEWorldGenPlugin</Id>
   <FriendlyName>SEWorldGenPlugin V2</FriendlyName>
   <GroupId>SEWorldGenPlugin</GroupId>
-  <Commit>9f58b2a797aa5487cdb2b4a0a5b68e0fe4059812</Commit>
+  <Commit>7e65a26fbfb5e32d9c940a3aef964218796d92f6</Commit>
   <Hidden>true</Hidden>
 </PluginData>


### PR DESCRIPTION
It should fix the issues it had with the plugin loader github plugins by hardcoding the storage folder and removing a duplicate file that should not have been on the github thanks to @austinvaness.