### PR TITLE
Add RemoveIntroVideoPlugin

### DIFF
--- a/Plugins/RemoveIntroVideoPlugin.xml
+++ b/Plugins/RemoveIntroVideoPlugin.xml
@@ -3,6 +3,6 @@
   <Id>WesternGamer/RemoveIntroVideoPlugin</Id>
   <GroupId>RemoveIntroVideoPlugin</GroupId>
   <FriendlyName>Remove Intro Video Plugin</FriendlyName>
-  <Tooltip>Allows scrolling between welder, grinder, and drill.</Tooltip>
+  <Tooltip>This plugin disables the intro video that is played when you open Space Engineers.</Tooltip>
   <Commit>ce0c99b37d04b5dbdeafe239b49e0e5a79ee6c65</Commit>
 </PluginData>

--- a/Plugins/RemoveIntroVideoPlugin.xml
+++ b/Plugins/RemoveIntroVideoPlugin.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>WesternGamer/RemoveIntroVideoPlugin</Id>
+  <GroupId>RemoveIntroVideoPlugin</GroupId>
+  <FriendlyName>Remove Intro Video Plugin</FriendlyName>
+  <Tooltip>Allows scrolling between welder, grinder, and drill.</Tooltip>
+  <Commit>ce0c99b37d04b5dbdeafe239b49e0e5a79ee6c65</Commit>
+</PluginData>


### PR DESCRIPTION
The plugin disables the intro video that is played when you open Space Engineers. The purpose of this plugin is to make disabling the intro video more streamlined for users of PluginLoader.