### PR TITLE
HideVersionString 1.0.1 Update

### DIFF
--- a/Plugins/HideVersionString.xml
+++ b/Plugins/HideVersionString.xml
@@ -5,5 +5,5 @@
   <FriendlyName>Hide Version String</FriendlyName>
   <Author>WesternGamer</Author>
   <Tooltip>Makes the Main Menu cleaner by hiding the the version string.</Tooltip>
-  <Commit>f9813ccc474c07a69d57d0b47463d152a5348b22</Commit>
+  <Commit>a789c1e7673233f00ad182c335da0279d76be274</Commit>
 </PluginData>


### PR DESCRIPTION
-Fixed issue where options button was missing on main menu. This should also prevent future issues with other plugins.
-Moved version string to bottom right in option selection menu.