### PR TITLE
FileCleaner bug fix

### DIFF
--- a/Plugins/FileCleaner.xml
+++ b/Plugins/FileCleaner.xml
@@ -5,5 +5,5 @@
   <FriendlyName>File Cleaner</FriendlyName>
   <Author>WesternGamer</Author>
   <Tooltip>This plugin deletes temporary files and log files when you launch the game.</Tooltip>
-  <Commit>e223d0e7d99abd06db7b250f2ecac4278761c3fe</Commit>
+  <Commit>4518fde375ecd6b8e9c17ff37630552abee1539d</Commit>
 </PluginData>


### PR DESCRIPTION
Fixed issue where exception would be thrown when a folder(s) that the plugin is searching for does not exist.