### PR TITLE
New Plugin

### DIFF
--- a/Plugins/InGameWorldLoading.xml
+++ b/Plugins/InGameWorldLoading.xml
@@ -1,0 +1,10 @@
+
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>WesternGamer/InGameWorldLoading</Id>
+  <GroupId>InGameWorldLoading</GroupId>
+  <FriendlyName>In Game World Loading</FriendlyName>
+  <Author>WesternGamer</Author>
+  <Tooltip>Adds the ability to load, join, or start a new world from ingame.</Tooltip>
+  <Commit>8c8a2ad8146ce02d98074fd72e9fe8bdcebd5845</Commit>
+</PluginData>


### PR DESCRIPTION
Plugin: InGameWorldLoading
Description: Adds the ability to load, join, or start a new world from ingame.
Link: https://github.com/WesternGamer/InGameWorldLoading