### PR TITLE
RDR2DeathScreen

### DIFF
--- a/Plugins/RDR2DeathScreen.xml
+++ b/Plugins/RDR2DeathScreen.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>austinvaness/RDR2DeathScreen</Id>
+  <GroupId>RDR2DeathScreen</GroupId>
+  <FriendlyName>[BETA]: RDR2 Death Screen</FriendlyName>
+  <Author>WesternGamer</Author>
+  <Tooltip>Shows the Red Dead Redemption 2 death screen when player dies.</Tooltip>
+  <Commit>52fb414b41aa121db595e5281c71426905fa659d</Commit>
+  <Hidden>true</Hidden>
+</PluginData>


### PR DESCRIPTION
This plugin adds a death screen from Red Dead Redemption 2 when the player dies.
NOTES: Plugin is in BETA. Unknown if plugin loader supports embedded files. If not, embedded plugin file support would be a good addition.
Source: https://github.com/WesternGamer/RDR2DeathScreen

