### PR TITLE
RDR2 Death Screen With Changes

### DIFF
--- a/Plugins/RDR2DeathScreen.xml
+++ b/Plugins/RDR2DeathScreen.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>austinvaness/RDR2DeathScreen</Id>
+  <GroupId>RDR2DeathScreen</GroupId>
+  <FriendlyName>[BETA]: RDR2 Death Screen</FriendlyName>
+  <Author>WesternGamer</Author>
+  <Tooltip>Shows the Red Dead Redemption 2 death screen when player dies.</Tooltip>
+  <Commit>52fb414b41aa121db595e5281c71426905fa659d</Commit>
+  <Hidden>true</Hidden>
+</PluginData>

--- a/Plugins/RDR2DeathScreen.xml
+++ b/Plugins/RDR2DeathScreen.xml
@@ -5,6 +5,6 @@
   <FriendlyName>[BETA]: RDR2 Death Screen</FriendlyName>
   <Author>WesternGamer</Author>
   <Tooltip>Shows the Red Dead Redemption 2 death screen when player dies.</Tooltip>
-  <Commit>52fb414b41aa121db595e5281c71426905fa659d</Commit>
+  <Commit>2e624978d6acdc7d19ed58fff612e137c01f62f2</Commit>
   <Hidden>true</Hidden>
 </PluginData>


### PR DESCRIPTION
I made the plugin download the required files once only when the plugin is ran for the first time. I also redid the repo to show the correct project as it was showing the old project instead.

Source: https://github.com/WesternGamer/RDR2DeathScreen