### PR TITLE
RDR2DeathScreen Nexus Server Fix.

### DIFF
--- a/Plugins/RDR2DeathScreen.xml
+++ b/Plugins/RDR2DeathScreen.xml
@@ -5,6 +5,6 @@
   <FriendlyName>[BETA]: RDR2 Death Screen</FriendlyName>
   <Author>WesternGamer</Author>
   <Tooltip>Shows the Red Dead Redemption 2 death screen when player dies.</Tooltip>
-  <Commit>2e624978d6acdc7d19ed58fff612e137c01f62f2</Commit>
+  <Commit>dbfc5c39dbde30bc8870e8658c66b0787a773dd8</Commit>
   <Hidden>true</Hidden>
 </PluginData>


### PR DESCRIPTION
-Hopefully fixed null reference issue when switching between nexus servers.  